### PR TITLE
fix for non-random behaviour

### DIFF
--- a/mev0.py
+++ b/mev0.py
@@ -400,7 +400,7 @@ def sim2(
         chosenone = int(np.random.rand() * avlength) + startav 
         outorderprobs = np.array([np.zeros(startav - 1, 1), np.tile(1 / avlength, [Niters - startav, 1])])
     
-    chosenparticle = int(np.ceil(np.random.rand() * Nparticles))
+    chosenparticle = int(np.floor(np.random.rand() * Nparticles))
     outorder = outorderlist.astype(int)[:, chosenparticle, chosenone]
     outorderpos = np.copy(outorder)
     outorderpos[outorder] = np.arange(Nc, dtype=int)

--- a/pvoting.py
+++ b/pvoting.py
@@ -259,6 +259,7 @@ class ProbabilisticVotingClassifier(ClassifierMixin, _BaseVoting):
             # pass in k x c probas (scaled by x10?) into marginstableorcreateseed
             probas_reshape = probas.transpose((1, 0, 2)).reshape(-1, c*k)   # n x (c*k)
             # _st = time.perf_counter()
+            # np.random.seed(0) # for consistent results
             mev0_orders = np.apply_along_axis(
                 lambda x: sim2(
                     marginstableorcreateseed=10.*x.reshape(c, k),   # scale scores for stability?
@@ -268,6 +269,7 @@ class ProbabilisticVotingClassifier(ClassifierMixin, _BaseVoting):
                     # control accuracy vs time trade-off (TODO pass in parameters)
                     # Niters=20, 
                     # Nparticles=20,
+                    seed=np.random.randint(2**31),
                     **self.mev0_kwargs,
                 )[0],
                 axis=1,


### PR DESCRIPTION
"chosenparticle" and "chosenone" were always being picked the same, due to the 'np.random.seed(seed)' line, which was not being updated between calls to sim2

Additionally, this change exposes a tiny bug, previously hidden due to (chosenparticle, chosenone) always being equal to (11, 5), but which could otherwise throw an out_of_bounds error.